### PR TITLE
增加 hoverRange API，用于自定义点击日期时选中的日期区间

### DIFF
--- a/docs/example/DateRangePickerHoverRange.js
+++ b/docs/example/DateRangePickerHoverRange.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import moment from 'moment';
+import DateRangePicker from '../../src';
+
+const DateRangePickerHoverRange = props => (
+  <div className="field">
+    <DateRangePicker
+      hoverRange="week"
+    />
+    <DateRangePicker
+      hoverRange={date => [date.clone().subtract(1, 'days'), date.clone().add(1, 'days')]}
+    />
+  </div>
+);
+
+export default DateRangePickerHoverRange;
+

--- a/docs/index.js
+++ b/docs/index.js
@@ -13,6 +13,7 @@ import DateRangePickerIntl from './example/DateRangePickerIntl';
 import DateRangePickerValue from './example/DateRangePickerValue';
 import DateRangePickerToggle from './example/DateRangePickerToggle';
 import DateRangePickerInModal from './example/DateRangePickerInModal';
+import DateRangePickerHoverRange from './example/DateRangePickerHoverRange';
 
 class App extends Component {
   render() {
@@ -40,8 +41,8 @@ class App extends Component {
             <Col md={2} xsHidden smHidden>
               <Affix
                 offsetTop={70}
-                ref={(ref)=>{
-                  this.affix=ref;
+                ref={(ref) => {
+                  this.affix = ref;
                 }}
               >
                 <Nav className="sidebar">
@@ -49,6 +50,7 @@ class App extends Component {
                   <Nav.Item href="#default">示例</Nav.Item>
                   <Nav.Item href="#default">&nbsp;&nbsp;- 默认</Nav.Item>
                   <Nav.Item href="#disabled">&nbsp;&nbsp;- 禁用</Nav.Item>
+                  <Nav.Item href="#hover-range">&nbsp;&nbsp;- 选择整周、整月</Nav.Item>
                   <Nav.Item href="#custom-toolbar">&nbsp;&nbsp;- 自定义快捷项</Nav.Item>
                   <Nav.Item href="#locale">&nbsp;&nbsp;- 本地化</Nav.Item>
                   <Nav.Item href="#controlled">&nbsp;&nbsp;- 非受控与受控</Nav.Item>
@@ -79,6 +81,13 @@ class App extends Component {
               <DateRangePickerDisabled />
               <Markdown>
                 {require('./md/DateRangePickerDisabled.md')}
+              </Markdown>
+
+              <hr id="hover-range" className="target-fix" />
+              <h3>选择整周、整月</h3>
+              <DateRangePickerHoverRange />
+              <Markdown>
+                {require('./md/DateRangePickerHoverRange.md')}
               </Markdown>
 
               <hr id="custom-toolbar" className="target-fix" />

--- a/docs/md/DateRangePickerHoverRange.md
+++ b/docs/md/DateRangePickerHoverRange.md
@@ -1,0 +1,6 @@
+```html
+<DateRangePicker hoverRange="week"} />
+<DateRangePicker
+  hoverRange={date => [date.clone().subtract(1, 'days'), date.clone().add(1, 'days')]}
+/>
+```

--- a/docs/md/props.md
+++ b/docs/md/props.md
@@ -13,3 +13,4 @@
 | disabled          | boolean                                                     |                 | 禁用组件                    |
 | disabledDate      | function(`date`:moment, `value`:array(moment, moment))      |                 | 禁用日期                    |
 | align             | string                                                      | `left`          | 对齐方式，选项 `left`, `right` |
+| hoverRange        | "week", "month" or function(`date`: moment)                 |                 | 点击日期时将选中的日期范围|

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "lodash": "^4.17.4",
     "moment": ">=2.15.2",
     "prop-types": "^15.5.10",
-    "rsuite-theme": "^2.0.0-beta.1-1",
-    "rsuite-utils": "^0.0.9"
+    "rsuite-theme": "^2.0.0-beta.1-2",
+    "rsuite-utils": "0.0.9"
   },
   "peerDependencies": {
     "react": "^0.14.9 || >=15.3.0",
@@ -78,7 +78,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.1.1",
     "karma-mocha-reporter": "^2.0.4",
-    "karma-sinon-chai": "^1.2.2",
+    "karma-sinon-chai": "^1.3.3",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "2.0.3",
     "less": "^2.7.1",
@@ -89,7 +89,7 @@
     "react": "15.6.2",
     "react-dom": "15.6.2",
     "react-hot-loader": "^3.0.0-beta.6",
-    "rsuite": "^2.0.5",
+    "rsuite": "^2.0.8",
     "rsuite-affix": "^1.0.3",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",

--- a/src/Calendar/MonthView.js
+++ b/src/Calendar/MonthView.js
@@ -9,6 +9,7 @@ import Weeks from './Weeks';
 const propTypes = {
   activeDate: PropTypes.instanceOf(moment),
   value: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
+  hoverValue: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   onClick: PropTypes.func,
   onMouseMove: PropTypes.func,
   disabledDate: PropTypes.func
@@ -19,10 +20,10 @@ const defaultProps = {
 };
 
 /**
-  * Get all weeks of this month
-  * @params monthDate
-  * @return date[]
-  */
+ * Get all weeks of this month
+ * @params monthDate
+ * @return date[]
+ */
 function getMonthView(monthDate) {
 
   let firstDayOfMonth = monthDate.day();
@@ -53,6 +54,7 @@ class MonthView extends React.Component {
     const {
       activeDate,
       value,
+      hoverValue,
       onClick,
       onMouseMove,
       disabledDate,
@@ -74,6 +76,7 @@ class MonthView extends React.Component {
           <Weeks
             weeks={getMonthView(thisMonthDate)}
             selected={value}
+            hoverValue={hoverValue}
             onClick={onClick}
             onMouseMove={onMouseMove}
             inSameMonth={date => inSameMonth(date, thisMonthDate)}

--- a/src/Calendar/Week.js
+++ b/src/Calendar/Week.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 const propTypes = {
   weekendDate: PropTypes.instanceOf(moment),
   selected: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
+  hoverValue: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   onClick: PropTypes.func,
   disabledDate: PropTypes.func,
   inSameMonth: PropTypes.func,
@@ -14,7 +15,8 @@ const propTypes = {
 };
 
 const defaultProps = {
-  selected: []
+  selected: [],
+  hoverValue: []
 };
 
 class Week extends React.Component {
@@ -25,6 +27,7 @@ class Week extends React.Component {
       disabledDate,
       inSameMonth,
       selected,
+      hoverValue,
       onClick,
       onMouseMove
     } = this.props;
@@ -50,10 +53,21 @@ class Week extends React.Component {
       }
 
       let unSameMonth = !(inSameMonth && inSameMonth(thisDate));
+
+      const isSelected = !unSameMonth && ((selected[0] && thisDate.isSame(selected[0], 'date')) || (selected[1] && thisDate.isSame(selected[1], 'date')));
+      if (!isSelected && hoverValue[1] && hoverValue[0]) {
+        if (!thisDate.isAfter(hoverValue[1], 'date') && !thisDate.isBefore(hoverValue[0], 'date')) {
+          inRange = true;
+        }
+        if (!thisDate.isAfter(hoverValue[0], 'date') && !thisDate.isBefore(hoverValue[1], 'date')) {
+          inRange = true;
+        }
+      }
+
       let classes = classNames('week-day', {
         'un-same-month': unSameMonth,
         'is-today': isToday,
-        selected: !unSameMonth && ((selected[0] && thisDate.isSame(selected[0], 'date')) || (selected[1] && thisDate.isSame(selected[1], 'date'))),
+        selected: isSelected,
         'in-range': !unSameMonth && inRange,
         disabled
       });
@@ -81,7 +95,7 @@ class Week extends React.Component {
     const {
       className,
       ...props
-     } = this.props;
+    } = this.props;
 
     const classes = classNames('week', className);
     const elementProps = _.omit(props, Object.keys(propTypes));

--- a/src/Calendar/Weeks.js
+++ b/src/Calendar/Weeks.js
@@ -10,6 +10,7 @@ const propTypes = {
   /* eslint-disable */
   weeks: PropTypes.array,
   selected: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
+  hoverValue: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   onClick: PropTypes.func,
   onMouseMove: PropTypes.func,
   disabledDate: PropTypes.func,
@@ -25,6 +26,7 @@ class Weeks extends React.Component {
     const {
       weeks,
       selected,
+      hoverValue,
       onClick,
       onMouseMove,
       disabledDate,
@@ -48,6 +50,7 @@ class Weeks extends React.Component {
               key={index}
               weekendDate={week}
               selected={selected}
+              hoverValue={hoverValue}
               onClick={onClick}
               onMouseMove={onMouseMove}
               inSameMonth={inSameMonth}

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -15,6 +15,7 @@ const propTypes = {
   index: PropTypes.number,
   calendarDate: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   value: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
+  hoverValue: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   onMoveForword: PropTypes.func,
   onMoveBackward: PropTypes.func,
   onSelect: PropTypes.func,
@@ -113,6 +114,7 @@ class Calendar extends React.Component {
       calendarRef,
       className,
       value,
+      hoverValue,
       ...props
     } = this.props;
 
@@ -131,6 +133,7 @@ class Calendar extends React.Component {
         key={'MonthView'}
         activeDate={pageDate}
         value={value}
+        hoverValue={hoverValue}
         onClick={onSelect}
         onMouseMove={onMouseMove}
         disabledDate={disabledDate}

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -7,6 +7,7 @@ import decorate from './utils/decorate';
 const propTypes = {
   disabledDate: PropTypes.func,
   value: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
+  hoverValue: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   calendarDate: PropTypes.arrayOf(PropTypes.instanceOf(moment)),
   index: PropTypes.number,
   format: PropTypes.string,
@@ -69,6 +70,7 @@ class DatePicker extends Component {
     const {
       format,
       value,
+      hoverValue,
       index,
       calendarDate,
       onSelect,
@@ -83,6 +85,7 @@ class DatePicker extends Component {
         disabledDate={disabledDate}
         format={format}
         value={value}
+        hoverValue={hoverValue}
         calendarState={calendarState}
         calendarDate={calendarDate}
         index={index}

--- a/src/DateRangePicker.js
+++ b/src/DateRangePicker.js
@@ -26,7 +26,12 @@ const propTypes = {
   locale: PropTypes.object,
   onChange: PropTypes.func,
   onToggle: PropTypes.func,
-  onOk: PropTypes.func
+  onOk: PropTypes.func,
+
+  hoverRange: PropTypes.oneOfType([
+    PropTypes.oneOf(['week', 'month']),
+    PropTypes.func
+  ])
 };
 
 const defaultProps = {
@@ -73,7 +78,10 @@ class DateRangePicker extends Component {
       doneSelected: true,
       calendarState: 'HIDE',
       // display calendar date
-      calendarDate
+      calendarDate,
+
+      // 当前应该高亮哪个区间，用于实现选择整周、整月
+      hoverValue: []
     };
 
   }
@@ -97,6 +105,7 @@ class DateRangePicker extends Component {
   get isMounted() {
     return this.mounted;
   }
+
   set isMounted(isMounted) {
     this.mounted = isMounted;
   }
@@ -225,17 +234,62 @@ class DateRangePicker extends Component {
     this.setState({ calendarDate });
   }
 
+  // hover range presets
+  getWeekHoverRange = date => [date.clone().startOf('week'), date.clone().endOf('week')];
+  getMonthHoverRange = date => [date.clone().startOf('month'), date.clone().endOf('month')];
+
+  getHoverRange(date) {
+    const { hoverRange } = this.props;
+    if (!hoverRange) {
+      return [];
+    }
+
+    let hoverRangeFunc = hoverRange;
+    if (hoverRange === 'week') {
+      hoverRangeFunc = this.getWeekHoverRange;
+    }
+    if (hoverRangeFunc === 'month') {
+      hoverRangeFunc = this.getMonthHoverRange;
+    }
+    if (typeof hoverRangeFunc !== 'function') {
+      return [];
+    }
+
+    const hoverValues = hoverRangeFunc(date.clone());
+    const isHoverRangeValid = hoverValues instanceof Array && hoverValues.length === 2;
+    if (!isHoverRangeValid) {
+      return [];
+    }
+    if (hoverValues[0].isAfter(hoverValues[1])) {
+      hoverValues.reverse();
+    }
+    return hoverValues;
+  }
+
   handleChangeSelectValue = (date) => {
     const { selectValue, doneSelected } = this.state;
     let nextValue = [];
+    let nextHoverValue = this.getHoverRange(date);
 
     if (doneSelected) {
-      nextValue = [date, undefined, date];
+      if (nextHoverValue.length) {
+        nextValue = [nextHoverValue[0], nextHoverValue[1], date];
+        nextHoverValue = [nextHoverValue[0], nextHoverValue[1], date];
+      } else {
+        nextValue = [date, undefined, date];
+      }
     } else {
-      nextValue = [
-        selectValue[0],
-        date
-      ];
+      if (nextHoverValue.length) {
+        nextValue = [
+          selectValue[0],
+          selectValue[1]
+        ];
+      } else {
+        nextValue = [
+          selectValue[0],
+          date
+        ];
+      }
 
       if (nextValue[0].isAfter(nextValue[1])) {
         nextValue.reverse();
@@ -254,20 +308,33 @@ class DateRangePicker extends Component {
 
     this.setState({
       doneSelected: !doneSelected,
-      selectValue: nextValue
+      selectValue: nextValue,
+      hoverValue: nextHoverValue
     });
 
   }
 
   handleMouseMoveSelectValue = (date) => {
-    const { doneSelected, selectValue } = this.state;
+    const { doneSelected, selectValue, hoverValue } = this.state;
+    let nextHoverValue = this.getHoverRange(date);
 
     if (doneSelected) {
+      this.setState({
+        hoverValue: nextHoverValue
+      });
       return;
     }
 
     let nextValue = selectValue;
-    nextValue[1] = date;
+    if (!nextHoverValue.length) {
+      nextValue[1] = date;
+    } else {
+      nextValue = [
+        nextHoverValue[0].isBefore(hoverValue[0]) ? nextHoverValue[0] : hoverValue[0],
+        nextHoverValue[1].isAfter(hoverValue[1]) ? nextHoverValue[1] : hoverValue[1],
+        nextValue[2]
+      ];
+    }
 
     // If `nextValue[0]` is greater than `nextValue[1]` then reverse order
     if (nextValue[0].isAfter(nextValue[1])) {
@@ -275,7 +342,7 @@ class DateRangePicker extends Component {
     }
 
     this.setState({
-      selectValue: nextValue
+      selectValue: nextValue,
     });
   }
 
@@ -307,9 +374,9 @@ class DateRangePicker extends Component {
     // the button is disabled
     while (start.isBefore(end)) {
       if (disabledDate && disabledDate(start.clone(), [
-        selectValue && selectValue[0] ? selectValue[0].clone() : null,
-        selectValue && selectValue[1] ? selectValue[1].clone() : null,
-      ])) {
+          selectValue && selectValue[0] ? selectValue[0].clone() : null,
+          selectValue && selectValue[1] ? selectValue[1].clone() : null,
+        ])) {
         check = true;
       }
       start.add(1, 'd');
@@ -353,7 +420,8 @@ class DateRangePicker extends Component {
       calendarDate,
       selectValue,
       doneSelected,
-      toggleWidth
+      toggleWidth,
+      hoverValue
     } = this.state;
 
     const value = this.getValue();
@@ -376,6 +444,7 @@ class DateRangePicker extends Component {
           index={0}
           doneSelected={doneSelected}
           value={selectValue}
+          hoverValue={hoverValue}
           disabledDate={disabledDate ? (a, b) => disabledDate(a, b, doneSelected) : null}
           calendarDate={calendarDate}
           onSelect={this.handleChangeSelectValue}
@@ -387,6 +456,7 @@ class DateRangePicker extends Component {
           doneSelected={doneSelected}
           calendarDate={calendarDate}
           value={selectValue}
+          hoverValue={hoverValue}
           disabledDate={disabledDate ? (a, b) => disabledDate(a, b, doneSelected) : null}
           onSelect={this.handleChangeSelectValue}
           onMouseMove={this.handleMouseMoveSelectValue}

--- a/src/DateRangePicker.js
+++ b/src/DateRangePicker.js
@@ -81,7 +81,10 @@ class DateRangePicker extends Component {
       calendarDate,
 
       // 当前应该高亮哪个区间，用于实现选择整周、整月
-      hoverValue: []
+      hoverValue: [],
+
+      // 当前 hover 的 date，用来减少 handleMouseMoveSelectValue 的计算
+      currentHoverDate: null
     };
 
   }
@@ -315,11 +318,15 @@ class DateRangePicker extends Component {
   }
 
   handleMouseMoveSelectValue = (date) => {
-    const { doneSelected, selectValue, hoverValue } = this.state;
+    const { doneSelected, selectValue, hoverValue, currentHoverDate } = this.state;
+    if (date.isSame(currentHoverDate, 'day')) {
+      return;
+    }
     let nextHoverValue = this.getHoverRange(date);
 
     if (doneSelected) {
       this.setState({
+        currentHoverDate: date,
         hoverValue: nextHoverValue
       });
       return;
@@ -342,6 +349,7 @@ class DateRangePicker extends Component {
     }
 
     this.setState({
+      currentHoverDate: date,
       selectValue: nextValue,
     });
   }

--- a/test/DateRangePickerSpec.js
+++ b/test/DateRangePickerSpec.js
@@ -42,14 +42,13 @@ describe('DateRangePicker', () => {
         done();
       }
     };
+
     const instance = ReactTestUtils.renderIntoDocument(
       <DateRangePicker onToggle={doneOp} />
     );
     const instanceDOM = findDOMNode(instance);
     ReactTestUtils.Simulate.click(instanceDOM.querySelector('.rsuite-daterangepicker-toggle'));
   });
-
-
 
   it('Should have a custom className', () => {
     const instance = ReactTestUtils.renderIntoDocument(
@@ -67,5 +66,24 @@ describe('DateRangePicker', () => {
     assert.equal(findDOMNode(instance).style.fontSize, fontSize);
   });
 
+  it('Should select a whole week', (done) => {
+    const doneOp = (values) => {
+      if (moment().startOf('week').isSame(values[0], 'date') && moment().endOf('week').isSame(values[1], 'date')) {
+        done();
+      }
+    };
+    const instance = ReactTestUtils.renderIntoDocument(
+      <DateRangePicker
+        onOk={doneOp}
+        hoverRange="week"
+      />
+    );
+    const instanceDOM = findDOMNode(instance);
+    const today = instanceDOM.querySelector('.week-day.is-today');
+    ReactTestUtils.Simulate.click(today);
+    ReactTestUtils.Simulate.click(today);
+    ReactTestUtils.Simulate.click(instanceDOM.querySelector('.rsuite-daterangepicker-toolbar-right-btn-ok'));
+
+  });
 
 });


### PR DESCRIPTION
可设置 `hoverRange="week`, `hoverRange="month"`, `hoverRange={date => [moment, moment]}`